### PR TITLE
Load MLLR transforms with only cluster properly

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/decoder/adaptation/Transform.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/decoder/adaptation/Transform.java
@@ -135,7 +135,6 @@ public class Transform {
 
         Scanner input = new Scanner(new File(filePath));
         int numStreams, nMllrClass;
-        int[] vectorLength = new int[1];
 
         nMllrClass = input.nextInt();
 
@@ -143,25 +142,26 @@ public class Transform {
 
         numStreams = input.nextInt();
 
-        this.As = new float[nMllrClass][][][];
-        this.Bs = new float[nMllrClass][][];
+        this.As = new float[nMllrClass][numStreams][][];
+        this.Bs = new float[nMllrClass][numStreams][];
 
         for (int i = 0; i < numStreams; i++) {
-            vectorLength[i] = input.nextInt();
+            int length = input.nextInt();
 
-            int length = vectorLength[i];
-
-            this.As[0] = new float[numStreams][length][length];
-            this.Bs[0] = new float[numStreams][length];
+            this.As[0][i] = new float[length][length];
+            this.Bs[0][i] = new float[length];
 
             for (int j = 0; j < length; j++) {
-                for (int k = 0; k < length; ++k) {
+                for (int k = 0; k < length; k++) {
                     As[0][i][j][k] = input.nextFloat();
                 }
             }
-
             for (int j = 0; j < length; j++) {
                 Bs[0][i][j] = input.nextFloat();
+            }
+            for (int j = 0; j < length; j++) {
+                // Skip MLLR variance scale
+                input.nextFloat();
             }
         }
         input.close();


### PR DESCRIPTION
Row with MLLR variance scale wasn't read, causing InputMismatchException. Also reinitialization of matrix/vector rows on each iteration caused loss of loaded multipliers.