### PR TITLE
Fix NullPointerException with null logMath when using weighted JSGF grammars

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/jsgf/JSGFGrammar.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/jsgf/JSGFGrammar.java
@@ -204,15 +204,19 @@ public class JSGFGrammar extends Grammar {
             Dictionary dictionary) {
         super(showGrammar, optimizeGrammar, addSilenceWords, addFillerWords,
                 dictionary);
-        logMath = LogMath.getLogMath();
         this.baseURL = baseURL;
         this.grammarName = grammarName;
-        loadGrammar = true;
-        logger = Logger.getLogger(getClass().getName());
+        init();
     }
 
     public JSGFGrammar() {
+        init();
+    }
 
+    public void init() {
+        logMath = LogMath.getLogMath();
+        loadGrammar = true;
+        logger = Logger.getLogger(getClass().getName());
     }
 
     /*


### PR DESCRIPTION
I have a JSGF grammar with weights.

And got exception when using this grammar.
The problem is that JSGFGrammar is initialized with default constructor in FlatLinguist and logMath reamins null.

```
java.lang.NullPointerException
	at edu.cmu.sphinx.jsgf.JSGFGrammar.getNormalizedWeights(JSGFGrammar.java:493)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleAlternatives(JSGFGrammar.java:448)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:333)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleName(JSGFGrammar.java:392)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:337)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleSequence(JSGFGrammar.java:520)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:339)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleAlternatives(JSGFGrammar.java:458)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:333)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleCount(JSGFGrammar.java:414)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:335)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleSequence(JSGFGrammar.java:520)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:339)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRuleAlternatives(JSGFGrammar.java:458)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.processRule(JSGFGrammar.java:333)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.commitChanges(JSGFGrammar.java:636)
	at edu.cmu.sphinx.jsgf.JSGFGrammar.createGrammar(JSGFGrammar.java:298)
	at edu.cmu.sphinx.linguist.language.grammar.Grammar.allocate(Grammar.java:112)
	at edu.cmu.sphinx.linguist.flat.FlatLinguist.allocate(FlatLinguist.java:264)
	at edu.cmu.sphinx.decoder.search.WordPruningBreadthFirstSearchManager.allocate(WordPruningBreadthFirstSearchManager.java:243)
	at edu.cmu.sphinx.decoder.AbstractDecoder.allocate(AbstractDecoder.java:103)
	at edu.cmu.sphinx.recognizer.Recognizer.allocate(Recognizer.java:164)
        ...
```
