### PR TITLE
fix time parameter of Speech Signals

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/frontend/endpoint/SpeechMarker.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/frontend/endpoint/SpeechMarker.java
@@ -146,7 +146,7 @@ public class SpeechMarker extends BaseDataProcessor {
 
             if (data instanceof DataEndSignal) {
                 if (inSpeech) {
-                    outputQueue.add(new SpeechEndSignal());
+                    outputQueue.add(new SpeechEndSignal(((DataEndSignal)data).getDuration()));
                 }
                 outputQueue.add(data);
                 break;
@@ -174,7 +174,7 @@ public class SpeechMarker extends BaseDataProcessor {
 
                 if (!inSpeech && speechCount == startSpeechFrames) {
                     inSpeech = true;
-                    outputQueue.add(new SpeechStartSignal(cdata.getCollectTime() - speechLeader - startSpeechFrames));
+                    outputQueue.add(new SpeechStartSignal(cdata.getCollectTime() - speechLeader - startSpeechTime));
                     outputQueue.addAll(inputQueue.subList(
                             Math.max(0, inputQueue.size() - startSpeechFrames - speechLeaderFrames), inputQueue.size()));
                     inputQueue.clear();


### PR DESCRIPTION
Hello, I found the time statistics of the SpeedTracker is sometimes incorrect, with "This Time Audio: XX.Xs" being a very big number (actually it's a timestamp counting from 1970-01-01).
After tracing the code, I have found some issues regarding the time parameter of SpeechStartSignal/SpeechEndSignal, and fixed it by myself.

1. I think SpeechEndSignal should be constructed with a time parameter relative to the audio time, just like in line 184 in this file. Otherwise, the time will be set to a system timestamp, which will cause the above issue.
2. In the SpeechStartSignal constructor, the parameter is meant to be in millisecond (just like "cdata.getCollectTime()" and "speechLeader"). However, "startSpeechFrames" is counted in frame (which is "startSpeechTime"/10), so I have also changed this.

just some of my suggestions, I hope you would consider it, Thanks!
