### PR TITLE
Update SimpleTokenizer.java

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/alignment/SimpleTokenizer.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/alignment/SimpleTokenizer.java
@@ -15,16 +15,16 @@ import java.util.List;
 public class SimpleTokenizer implements TextTokenizer {
     public List<String> expand(String text) {
 
-        text = text.replace('’', '\'');
-        text = text.replace('‘', ' ');
-        text = text.replace('”', ' ');
-        text = text.replace('“', ' ');
-        text = text.replace('"', ' ');
-        text = text.replace('»', ' ');
-        text = text.replace('«', ' ');
-        text = text.replace('–', '-');
-        text = text.replace('—', ' ');
-        text = text.replace('…', ' ');
+        text = text.replace('\u2019', '\'');
+        text = text.replace('\u2018', ' ');
+        text = text.replace('\u201D', ' ');
+        text = text.replace('\u201C', ' ');
+        text = text.replace('\u0022', ' ');
+        text = text.replace('\u00BB', ' ');
+        text = text.replace('\u00AB', ' ');
+        text = text.replace('\u2013', '-');
+        text = text.replace('\u2014', ' ');
+        text = text.replace('\u2026', ' ');
 
         text = text.replace(" - ", " ");
         text = text.replaceAll("[/_*%]", " ");


### PR DESCRIPTION
A character encoding problem occurred when I cloned this repo.
I would recommend to use the unicode escapes instead of the unicode chars.