### PR TITLE
Fixing Javadoc duplicate with inheritDoc

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/linguist/acoustic/tiedstate/SenoneHMM.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/linguist/acoustic/tiedstate/SenoneHMM.java
@@ -90,9 +90,7 @@ public class SenoneHMM implements HMM {
 
 
     /**
-     * Returns the order of the HMM
-     *
-     * @return the order of the HMM
+     * {@inheritDoc}
      */
     // [[[NOTE: this method is probably not explicitly needed since
     // getSenoneSequence.getSenones().length will provide the same

--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/linguist/acoustic/trivial/TrivialAcousticModel.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/linguist/acoustic/trivial/TrivialAcousticModel.java
@@ -252,9 +252,7 @@ class TrivialHMM implements HMM {
 
 
     /**
-     * Returns the order of the HMM
-     *
-     * @return the order of the HMM
+     * {@inheritDoc}
      */
     public int getOrder() {
         return hmmStates.length;


### PR DESCRIPTION
I'm a PhD Student from University of Bordeaux working on documentation copy-pastes (duplicates).
I've noticed that your project does have a few documentation duplicates.
For my research work, i've fixed this simple duplicate and i'd love to have your feedback about it:

- Do you think that this duplicate documentation should co-evolve forever?
- Are you aware of copy-pastes in your documentation?
- If yes, how do you handle them?
- Were you aware of JavaDoc reuse features such as {@inheritDoc}?
- Would you like to have a tool that helps you maintain duplicate documentation?