### PR TITLE
Fix StringIndexOutOfBoundsException

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/alignment/USEnglishTokenizer.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/alignment/USEnglishTokenizer.java
@@ -999,8 +999,8 @@ public class USEnglishTokenizer implements TextTokenizer {
                 // is at least 3 letters long, is an alphabet sequence,
                 // and has a comma.
                 boolean previousIsCity =
-                        (Character.isUpperCase(previous.charAt(0))
-                                && previous.length() > 2
+                        (previous.length() > 2
+                                && Character.isUpperCase(previous.charAt(0))
                                 && matches(alphabetPattern, previous) && tokenItem
                                 .findFeature("p.punc").equals(","));
 


### PR DESCRIPTION
The length of previous string was not checked before retrieving the first character. When it is empty it throws exception