### PR TITLE
fix StringIndexOutOfBoundsException

### DIFF
--- a/sphinx4-core/src/main/java/edu/cmu/sphinx/util/BatchFile.java
+++ b/sphinx4-core/src/main/java/edu/cmu/sphinx/util/BatchFile.java
@@ -70,7 +70,10 @@ public class BatchFile {
      */
     public static String getFilename(String batchFileLine) {
         int firstSpace = batchFileLine.indexOf(' ');
-        return batchFileLine.substring(0, firstSpace).trim();
+        if (firstSpace >= 0) {
+            return batchFileLine.substring(0, firstSpace).trim();
+        }
+        return "";
     }
 
 
@@ -87,4 +90,3 @@ public class BatchFile {
     }
 }
 
-  


### PR DESCRIPTION
if batchFileLine is empty, it will throw StringIndexOutOfBoundsException when calling substring(0,-1);
[
![image](https://user-images.githubusercontent.com/44200574/140014035-79eb0773-96eb-4cb5-8902-f1454946a6a9.png)
](url)